### PR TITLE
Make @webauthntine/browser work in node env

### DIFF
--- a/packages/browser/src/helpers/supportsWebauthn.test.ts
+++ b/packages/browser/src/helpers/supportsWebauthn.test.ts
@@ -1,4 +1,4 @@
-import supportsWebauthn from './supportsWebauthn';
+import supportsWebauthn from './supportsWebauthn'
 
 beforeEach(() => {
   // @ts-ignore 2741
@@ -13,3 +13,16 @@ test('should return false when browser does not support WebAuthn', () => {
   delete window.PublicKeyCredential;
   expect(supportsWebauthn()).toBe(false);
 });
+
+test('should return false when window is undefined', () => {
+  // Make window undefined as it is in node environments.
+  // @ts-expect-error
+  const windowSpy = jest.spyOn(global, "window", "get");
+  windowSpy.mockImplementation(() => undefined);
+
+  expect(window).toBe(undefined)
+  expect(supportsWebauthn()).toBe(false);
+
+  // Restore original window value.
+  windowSpy.mockRestore()
+})

--- a/packages/browser/src/helpers/supportsWebauthn.ts
+++ b/packages/browser/src/helpers/supportsWebauthn.ts
@@ -3,7 +3,7 @@
  */
 export default function supportsWebauthn(): boolean {
   return (
-    window.PublicKeyCredential !== undefined
+    window?.PublicKeyCredential !== undefined
     && typeof window.PublicKeyCredential === 'function'
   );
 }

--- a/packages/browser/src/setupTests.ts
+++ b/packages/browser/src/setupTests.ts
@@ -3,6 +3,9 @@
 // jest.spyOn(console, 'debug').mockImplementation();
 // jest.spyOn(console, 'error').mockImplementation();
 
+// @ts-expect-error
+if (global.window) {
+
 /**
  * JSDom doesn't seem to support `credentials`, so let's define them here so we can mock their
  * implementations in specific tests.
@@ -14,3 +17,4 @@ window.navigator.credentials = {
   // assertion
   get: jest.fn(),
 };
+}

--- a/packages/browser/webpack.config.js
+++ b/packages/browser/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
     filename: 'webauthntine-browser.min.js',
     library: 'WebAuthntineBrowser',
     libraryTarget: 'umd',
+    globalObject: 'this',
   },
   plugins: [
     new WebpackAutoInject({


### PR DESCRIPTION
This is useful when `@webauthntine/browser` is used with SSR, e.g. using `nuxt.js` or `next.js`.

The first problem was that `window` is undefined in node which causes the `supportsWebauthn` method to throw an error trying to index undefined. This has been fixed by using typescript optional chaining.

The second problem is that the umd build is not working in node. This issue was discussed in https://github.com/webpack/webpack/issues/6784 and the solution is to use `output.globalObject: this` as also stated in [the docs](https://webpack.js.org/configuration/output/#outputglobalobject).

Closes #6 