### PR TITLE
Add support for excludeCredentials

### DIFF
--- a/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
+++ b/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
@@ -1,0 +1,22 @@
+import base64js from 'base64-js';
+
+/**
+ * A helper method to convert a base64 encoded credential id into a PublicKeyCredentialDescriptor,
+ * which is usable by allowCredentials and excludeCredentials.
+ */
+export default function toPublicKeyCredentialDescriptor(
+    base64CredentialId: string,
+    transports?: AuthenticatorTransport[]
+): PublicKeyCredentialDescriptor {
+    // Pad id with = characters until it is a multiple of 4 so it is a proper base64 encoded string.
+    // This is required because credential.id returned by navigor.credentials.get/create is base64 encoded but not padded.
+    const padLength = 4 - base64CredentialId.length % 4;
+    base64CredentialId = base64CredentialId.padEnd(base64CredentialId.length + padLength, '=');
+
+    return {
+      type: 'public-key',
+      id: base64js.toByteArray(base64CredentialId),
+      transports
+    };
+}
+  

--- a/packages/browser/src/methods/startAssertion.test.ts
+++ b/packages/browser/src/methods/startAssertion.test.ts
@@ -1,11 +1,8 @@
+import type { AssertionCredential, PublicKeyCredentialRequestOptionsJSON } from '@webauthntine/typescript-types';
 import base64js from 'base64-js';
-
-import { AssertionCredential, PublicKeyCredentialRequestOptionsJSON } from '@webauthntine/typescript-types';
-
 import toUint8Array from '../helpers/toUint8Array';
 import supportsWebauthn from '../helpers/supportsWebauthn';
 import toBase64String from '../helpers/toBase64String';
-
 import startAssertion from './startAssertion';
 
 jest.mock('../helpers/supportsWebauthn');

--- a/packages/browser/src/methods/startAssertion.ts
+++ b/packages/browser/src/methods/startAssertion.ts
@@ -1,13 +1,12 @@
-import {
+import type {
   PublicKeyCredentialRequestOptionsJSON,
   AuthenticatorAssertionResponseJSON,
   AssertionCredential,
 } from '@webauthntine/typescript-types';
-import base64js from 'base64-js';
-
 import toUint8Array from '../helpers/toUint8Array';
 import toBase64String from '../helpers/toBase64String';
 import supportsWebauthn from '../helpers/supportsWebauthn';
+import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 
 /**
  * Begin authenticator "login" via WebAuthn assertion
@@ -25,16 +24,9 @@ export default async function startAssertion(
   const publicKey: PublicKeyCredentialRequestOptions = {
     ...requestOptionsJSON.publicKey,
     challenge: toUint8Array(requestOptionsJSON.publicKey.challenge),
-    allowCredentials: requestOptionsJSON.publicKey.allowCredentials.map((cred) => {
-      // Make sure the credential ID length is a multiple of 4
-      const padLength = 4 - cred.id.length % 4;
-      let id = cred.id.padEnd(cred.id.length + padLength, '=');
-
-      return {
-        ...cred,
-        id: base64js.toByteArray(id),
-      };
-    })
+    allowCredentials: requestOptionsJSON.publicKey.allowCredentials.map(
+      ({ id, transports }) => toPublicKeyCredentialDescriptor(id, transports)
+    ),
   };
 
   // Wait for the user to complete assertion

--- a/packages/browser/src/methods/startAttestation.test.ts
+++ b/packages/browser/src/methods/startAttestation.test.ts
@@ -1,10 +1,7 @@
+import type { AttestationCredential, PublicKeyCredentialCreationOptionsJSON } from '@webauthntine/typescript-types';
 import base64js from 'base64-js';
-
-import { AttestationCredential, PublicKeyCredentialCreationOptionsJSON } from '@webauthntine/typescript-types';
-
 import toUint8Array from '../helpers/toUint8Array';
 import supportsWebauthn from '../helpers/supportsWebauthn';
-
 import startAttestation from './startAttestation';
 
 jest.mock('../helpers/supportsWebauthn');

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -8,6 +8,7 @@ test('should generate credential request options suitable for sending via JSON',
   const username = 'usernameHere';
   const timeout = 1;
   const attestationType = 'indirect';
+  const excludeCredentials = ['123abc'];
 
   const options = generateAttestationOptions(
     serviceName,
@@ -17,6 +18,7 @@ test('should generate credential request options suitable for sending via JSON',
     username,
     timeout,
     attestationType,
+    excludeCredentials,
   );
 
   expect(options).toEqual({
@@ -37,6 +39,10 @@ test('should generate credential request options suitable for sending via JSON',
       }],
       timeout,
       attestation: attestationType,
+      excludeCredentials: [{
+        type: 'public-key',
+        id: '123abc'
+      }],
     },
   });
 });

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -11,6 +11,7 @@ import { PublicKeyCredentialCreationOptionsJSON } from '@webauthntine/typescript
  * @param username User's website-specific username
  * @param timeout How long (in ms) the user can take to complete attestation
  * @param attestationType Request a full ("direct") or anonymized ("indirect") attestation statement
+ * @param excludeCredentials An array of base64 encoded credential ids that are not allowed to be used.
  */
 export default function generateAttestationOptions(
   serviceName: string,
@@ -20,6 +21,7 @@ export default function generateAttestationOptions(
   username: string,
   timeout: number = 60000,
   attestationType: 'direct' | 'indirect' = 'direct',
+  excludeCredentials?: string[]
 ): PublicKeyCredentialCreationOptionsJSON {
   return {
     publicKey: {
@@ -41,6 +43,11 @@ export default function generateAttestationOptions(
       }],
       timeout,
       attestation: attestationType,
+      excludeCredentials: excludeCredentials?.map(id => ({
+        id,
+        type: 'public-key',
+        transports: ['usb', 'ble', 'nfc', 'internal'],
+      })),
     },
   };
 }

--- a/packages/server/src/attestation/verifications/verifyFIDOU2F.ts
+++ b/packages/server/src/attestation/verifications/verifyFIDOU2F.ts
@@ -1,6 +1,5 @@
+import type { AttestationObject, VerifiedAttestation } from '@webauthntine/typescript-types';
 import base64url from 'base64url';
-import { AttestationObject, VerifiedAttestation } from '@webauthntine/typescript-types';
-
 import toHash from '@helpers/toHash';
 import convertCOSEtoPKCS from '@helpers/convertCOSEtoPKCS';
 import convertASN1toPEM from '@helpers/convertASN1toPEM';

--- a/packages/server/src/helpers/convertCOSEtoPKCS.test.ts
+++ b/packages/server/src/helpers/convertCOSEtoPKCS.test.ts
@@ -1,8 +1,6 @@
-import cbor from 'cbor';
 import { COSEKEYS } from '@webauthntine/typescript-types';
-
+import cbor from 'cbor';
 import convertCOSEtoPKCS from './convertCOSEtoPKCS';
-
 
 test('should throw an error curve if, somehow, curve coordinate x is missing', () => {
   const mockCOSEKey = new Map<number, number | Buffer>();

--- a/packages/server/src/helpers/convertCOSEtoPKCS.ts
+++ b/packages/server/src/helpers/convertCOSEtoPKCS.ts
@@ -1,7 +1,6 @@
 import cbor from 'cbor';
 import { COSEKEYS, COSEPublicKey } from '@webauthntine/typescript-types';
 
-
 /**
  * Takes COSE-encoded public key and converts it to PKCS key
  *

--- a/packages/server/src/helpers/decodeAttestationObject.ts
+++ b/packages/server/src/helpers/decodeAttestationObject.ts
@@ -1,7 +1,6 @@
 import base64url from 'base64url';
 import cbor from 'cbor';
-import { AttestationObject } from '@webauthntine/typescript-types';
-
+import type { AttestationObject } from '@webauthntine/typescript-types';
 
 /**
  * Convert an AttestationObject from base64 string to a proper object

--- a/packages/server/src/helpers/decodeClientDataJSON.ts
+++ b/packages/server/src/helpers/decodeClientDataJSON.ts
@@ -1,5 +1,4 @@
-import { ClientDataJSON } from '@webauthntine/typescript-types';
-
+import type { ClientDataJSON } from '@webauthntine/typescript-types';
 import asciiToBinary from './asciiToBinary';
 
 /**

--- a/packages/server/src/helpers/getCertificateInfo.ts
+++ b/packages/server/src/helpers/getCertificateInfo.ts
@@ -1,5 +1,5 @@
 import jsrsasign from 'jsrsasign';
-import { CertificateInfo } from '@webauthntine/typescript-types';
+import type { CertificateInfo } from '@webauthntine/typescript-types';
 
 type ExtInfo = {
   critical: boolean,

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -26,6 +26,12 @@ export type PublicKeyCredentialCreationOptionsJSON = {
     }],
     timeout?: number,
     attestation: 'direct' | 'indirect',
+    excludeCredentials?: { 
+      // Will be converted to a Uint8Array in the browser
+      id: string,
+      type: 'public-key',
+      transports?: AuthenticatorTransport[],
+     }[];
   },
 };
 
@@ -76,7 +82,7 @@ export interface AssertionCredential extends PublicKeyCredential {
 export interface AuthenticatorAttestationResponseJSON extends Omit<
 AuthenticatorAttestationResponse, 'clientDataJSON' | 'attestationObject'
 > {
-  base64ClientDataJSON: string,
+  base64ClientDataJSON: string;
   base64AttestationObject: string;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
+    "strict": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION


Can be used to prevent a single webauthn authenticator to be used multiple times for a single user account, which may impose a security risk (https://github.com/w3c/webauthn/issues/1235#issuecomment-501646115).

https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialdescriptor

https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/WebAuthn_Client_Registration.html