### PR TITLE
feature/exclude-credentials-attestation

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -104,6 +104,7 @@ app.get('/generate-attestation-options', (req, res) => {
      * The username can be a human-readable name, email, etc... as it is intended only for display.
      */
     username,
+    devices,
   } = user;
 
   /**
@@ -115,7 +116,22 @@ app.get('/generate-attestation-options', (req, res) => {
   inMemoryUserDeviceDB[loggedInUserId].currentChallenge = challenge;
 
   res.send(
-    generateAttestationOptions('WebAuthntine Example', rpID, challenge, loggedInUserId, username),
+    generateAttestationOptions(
+      'WebAuthntine Example',
+      rpID,
+      challenge,
+      loggedInUserId,
+      username,
+      60000,
+      'direct',
+      /**
+       * Passing in a user's list of already-registered authenticator IDs here prevents users from
+       * registering the same device multiple times. The authenticator will simply throw an error in
+       * the browser if it's asked to perform an attestation when one of these ID's already resides
+       * on it.
+       */
+      devices.map(dev => dev.base64CredentialID),
+    ),
   );
 });
 

--- a/example/public/register/index.html
+++ b/example/public/register/index.html
@@ -37,6 +37,7 @@
           attResp = await startAttestation(await resp.json());
         } catch (error) {
           elemError.innerText = error;
+          throw new Error(error);
         }
 
         const verificationResp = await fetch('/verify-attestation', {

--- a/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
+++ b/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
@@ -1,0 +1,16 @@
+import base64js from 'base64-js';
+import type { PublicKeyCredentialDescriptorJSON } from '@webauthntine/typescript-types';
+
+export default function toPublicKeyCredentialDescriptor(
+  descriptor: PublicKeyCredentialDescriptorJSON,
+): PublicKeyCredentialDescriptor {
+  // Make sure the Base64'd credential ID length is a multiple of 4 or else toByteArray will throw
+  const { id } = descriptor;
+  const padLength = 4 - (id.length % 4);
+  const paddedId = id.padEnd(id.length + padLength, '=');
+
+  return {
+    ...descriptor,
+    id: base64js.toByteArray(paddedId),
+  };
+}

--- a/packages/browser/src/methods/startAssertion.ts
+++ b/packages/browser/src/methods/startAssertion.ts
@@ -3,11 +3,11 @@ import {
   AuthenticatorAssertionResponseJSON,
   AssertionCredential,
 } from '@webauthntine/typescript-types';
-import base64js from 'base64-js';
 
 import toUint8Array from '../helpers/toUint8Array';
 import toBase64String from '../helpers/toBase64String';
 import supportsWebauthn from '../helpers/supportsWebauthn';
+import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 
 /**
  * Begin authenticator "login" via WebAuthn assertion
@@ -25,16 +25,9 @@ export default async function startAssertion(
   const publicKey: PublicKeyCredentialRequestOptions = {
     ...requestOptionsJSON.publicKey,
     challenge: toUint8Array(requestOptionsJSON.publicKey.challenge),
-    allowCredentials: requestOptionsJSON.publicKey.allowCredentials.map(cred => {
-      // Make sure the credential ID length is a multiple of 4
-      const padLength = 4 - (cred.id.length % 4);
-      const id = cred.id.padEnd(cred.id.length + padLength, '=');
-
-      return {
-        ...cred,
-        id: base64js.toByteArray(id),
-      };
-    }),
+    allowCredentials: requestOptionsJSON.publicKey.allowCredentials.map(
+      toPublicKeyCredentialDescriptor,
+    ),
   };
 
   // Wait for the user to complete assertion

--- a/packages/browser/src/methods/startAttestation.test.ts
+++ b/packages/browser/src/methods/startAttestation.test.ts
@@ -38,6 +38,11 @@ const goodOpts1: PublicKeyCredentialCreationOptionsJSON = {
       name: 'username',
     },
     timeout: 1,
+    excludeCredentials: [{
+      id: 'authIdentifier',
+      type: 'public-key',
+      transports: ['internal'],
+    }],
   },
 };
 
@@ -64,6 +69,11 @@ test('should convert options before passing to navigator.credentials.create(...)
 
   expect(argsPublicKey.challenge).toEqual(toUint8Array(goodOpts1.publicKey.challenge));
   expect(argsPublicKey.user.id).toEqual(toUint8Array(goodOpts1.publicKey.user.id));
+  expect(argsPublicKey.excludeCredentials).toEqual([{
+    id: base64js.toByteArray('authIdentifier=='),
+    type: 'public-key',
+    transports: ['internal'],
+  }])
 
   done();
 });

--- a/packages/browser/src/methods/startAttestation.ts
+++ b/packages/browser/src/methods/startAttestation.ts
@@ -7,6 +7,7 @@ import {
 import toUint8Array from '../helpers/toUint8Array';
 import toBase64String from '../helpers/toBase64String';
 import supportsWebauthn from '../helpers/supportsWebauthn';
+import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDescriptor';
 
 /**
  * Begin authenticator "registration" via WebAuthn attestation
@@ -28,6 +29,9 @@ export default async function startAttestation(
       ...creationOptionsJSON.publicKey.user,
       id: toUint8Array(creationOptionsJSON.publicKey.user.id),
     },
+    excludeCredentials: creationOptionsJSON.publicKey.excludeCredentials.map(
+      toPublicKeyCredentialDescriptor,
+    ),
   };
 
   // Wait for the user to complete attestation

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -1,25 +1,29 @@
-import { PublicKeyCredentialRequestOptionsJSON } from '@webauthntine/typescript-types';
+import type {
+  PublicKeyCredentialRequestOptionsJSON,
+} from '@webauthntine/typescript-types';
 
 /**
  * Prepare a value to pass into navigator.credentials.get(...) for authenticator "login"
  *
  * @param challenge Random string the authenticator needs to sign and pass back
- * @param base64CredentialIDs Array of base64-encoded authenticator IDs registered by the user for
- * assertion
+ * @param allowedBase64CredentialIDs Array of base64-encoded authenticator IDs registered by the
+ * user for assertion
  * @param timeout How long (in ms) the user can take to complete assertion
+ * @param suggestedTransports Suggested types of authenticators for assertion
  */
 export default function generateAssertionOptions(
   challenge: string,
-  base64CredentialIDs: string[],
+  allowedBase64CredentialIDs: string[],
   timeout = 60000,
+  suggestedTransports: AuthenticatorTransport[] = ['usb', 'ble', 'nfc', 'internal'],
 ): PublicKeyCredentialRequestOptionsJSON {
   return {
     publicKey: {
       challenge,
-      allowCredentials: base64CredentialIDs.map(id => ({
+      allowCredentials: allowedBase64CredentialIDs.map(id => ({
         id,
         type: 'public-key',
-        transports: ['usb', 'ble', 'nfc', 'internal'],
+        transports: suggestedTransports,
       })),
       timeout,
     },

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -39,8 +39,28 @@ test('should generate credential request options suitable for sending via JSON',
       ],
       timeout,
       attestation: attestationType,
+      excludeCredentials: [],
     },
   });
+});
+
+test('should map excluded credential IDs if specified', () => {
+  const options = generateAttestationOptions(
+    'WebAuthntine',
+    'not.real',
+    'totallyrandomvalue',
+    '1234',
+    'usernameHere',
+    undefined,
+    undefined,
+    ['someIDhere'],
+  );
+
+  expect(options.publicKey.excludeCredentials).toEqual([{
+    id: 'someIDhere',
+    type: 'public-key',
+    transports: ['usb', 'ble', 'nfc', 'internal'],
+  }]);
 });
 
 test('defaults to 60 seconds if no timeout is specified', () => {

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -10,6 +10,9 @@ import { PublicKeyCredentialCreationOptionsJSON } from '@webauthntine/typescript
  * @param username User's website-specific username
  * @param timeout How long (in ms) the user can take to complete attestation
  * @param attestationType Request a full ("direct") or anonymized ("indirect") attestation statement
+ * @param excludedBase64CredentialIDs Array of base64-encoded authenticator IDs registered by the
+ * user so the user can't register the same credential multiple times
+ * @param suggestedTransports Suggested types of authenticators for attestation
  */
 export default function generateAttestationOptions(
   serviceName: string,
@@ -19,6 +22,8 @@ export default function generateAttestationOptions(
   username: string,
   timeout = 60000,
   attestationType: 'direct' | 'indirect' = 'direct',
+  excludedBase64CredentialIDs: string[] = [],
+  suggestedTransports: AuthenticatorTransport[] = ['usb', 'ble', 'nfc', 'internal'],
 ): PublicKeyCredentialCreationOptionsJSON {
   return {
     publicKey: {
@@ -42,6 +47,11 @@ export default function generateAttestationOptions(
       ],
       timeout,
       attestation: attestationType,
+      excludeCredentials: excludedBase64CredentialIDs.map((id) => ({
+        id,
+        type: 'public-key',
+        transports: suggestedTransports,
+      })),
     },
   };
 }

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -42,20 +42,21 @@ export type PublicKeyCredentialCreationOptionsJSON = {
  */
 export type PublicKeyCredentialRequestOptionsJSON = {
   publicKey: {
-    //
     challenge: string;
-    allowCredentials: {
-      // Will be converted to a Uint8Array in the browser
-      id: string;
-      type: 'public-key';
-      transports?: AuthenticatorTransport[];
-    }[];
+    allowCredentials: PublicKeyCredentialDescriptorJSON[];
     // extensions?: AuthenticationExtensionsClientInputs,
     rpId?: string;
     timeout?: number;
     userVerification?: UserVerificationRequirement;
   };
 };
+
+export interface PublicKeyCredentialDescriptorJSON extends Omit<
+PublicKeyCredentialDescriptor, 'id'
+> {
+  // Should be a Base64-encoded credential ID. Will be converted to a Uint8Array in the browser
+  id: string;
+}
 
 /**
  * The value returned from navigator.credentials.create()

--- a/packages/typescript-types/src/index.ts
+++ b/packages/typescript-types/src/index.ts
@@ -28,6 +28,7 @@ export type PublicKeyCredentialCreationOptionsJSON = {
     ];
     timeout?: number;
     attestation: 'direct' | 'indirect';
+    excludeCredentials: PublicKeyCredentialDescriptorJSON[];
   };
 };
 


### PR DESCRIPTION
This PR updates `generateAttestationOptions()` with the ability to pass in a list of credential IDs to exclude from the attestation process (thanks to @P4sca1 for getting the ball rolling on this). If an authenticator has already been used to perform an attestation, the authenticator will simply throw an error in the browser when it is asked to perform another attestation and an internal ID matches an entry in the attestation option's `excludeCredentials`:

<img width="477" alt="Screen Shot 2020-05-25 at 11 56 43 PM" src="https://user-images.githubusercontent.com/5166470/82869620-69527d80-9ee3-11ea-9513-d919ed0db5a5.png">

`generateAttestationOptions()` and `generateAssertionOptions()` also gained the ability for suggested authenticator transports to be passed in. In both cases these will default to suggesting all types of authenticators.