### PR TITLE
feature/project-rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- omit in toc -->
-# WebAuthntine Project
+# SimpleWebAuthn Project
 ![WebAuthn](https://img.shields.io/badge/WebAuthn-Simplified-blueviolet?style=for-the-badge&logo=WebAuthn)
-[![npm (scoped)](https://img.shields.io/npm/v/@webauthntine/server?style=for-the-badge&logo=npm)](https://www.npmjs.com/search?q=webauthntine)
+[![npm (scoped)](https://img.shields.io/npm/v/@simplewebauthn/server?style=for-the-badge&logo=npm)](https://www.npmjs.com/search?q=simplewebauthn)
 
 - [Overview](#overview)
 - [Philosophy](#philosophy)
@@ -14,12 +14,12 @@
 This monorepo contains two complimentary libraries to help reduce the amount of work needed to
 incorporate WebAuthn into a website. The following packages are maintained here:
 
-- [@webauthntine/server](./packages/server/)
-- [@webauthntine/browser](./packages/browser)
+- [@simplewebauthn/server](./packages/server/)
+- [@simplewebauthn/browser](./packages/browser)
 
 An additional package is also included that contains shared TypeScript definitions:
 
-- [@webauthntine/typescript-types](./packages/typescript-types/)
+- [@simplewebauthn/typescript-types](./packages/typescript-types/)
 
 See these packages' READMEs for more specific implementation information.
 
@@ -39,15 +39,15 @@ Website front ends have their own part to play in the process:
 
 On the surface, this is a relatively straightforward dance. Unfortunately the values passed into the `navigator.credentials` methods and the responses received from them make heavy use of `ArrayBuffer`'s which are difficult to transmit as JSON between front end and back end. Not only that, there are many complex ways in which authenticator responses must be parsed, and though finalized, [the W3C spec](https://w3c.github.io/webauthn/) is quite complex and is being expanded all the time.
 
-**Enter WebAuthntine.**
+**Enter SimpleWebAuthn.**
 
-WebAuthntine attempts to offer a developer-friendly pair of libraries that simplify the above dance. [@webauthntine/server](./packages/server/) exports a small number of methods requiring a handful of simple inputs that pair with the two primary methods exported by [@webauthntine/browser](./packages/browser). No converting back and forth between `Uint8Array` (or was this supposed to be an `ArrayBuffer`...?) and `String`, no worrying about JSON compatibility - **WebAuthntine takes care of it all!**
+SimpleWebAuthn attempts to offer a developer-friendly pair of libraries that simplify the above dance. [@simplewebauthn/server](./packages/server/) exports a small number of methods requiring a handful of simple inputs that pair with the two primary methods exported by [@simplewebauthn/browser](./packages/browser). No converting back and forth between `Uint8Array` (or was this supposed to be an `ArrayBuffer`...?) and `String`, no worrying about JSON compatibility - **SimpleWebAuthn takes care of it all!**
 
 For a practical guide to implementing these to libraries, take a look at the [example project](./example). It includes a single-file Express server and a few HTML files that, combined with the packages in this repo, are close to all it takes to get up and running with WebAuthn.
 
 ## Tested Devices
 
-WebAuthn support is currently spotty, but getting better. Here are things I've tested that I know support WebAuthn and work fine with the WebAuthntine example:
+WebAuthn support is currently spotty, but getting better. Here are things I've tested that I know support WebAuthn and work fine with the SimpleWebAuthn example:
 
 | OS      | Browser |                  Authenticator |
 | :------ | :-----: | -----------------------------: |
@@ -57,7 +57,7 @@ WebAuthn support is currently spotty, but getting better. Here are things I've t
 | Android | Chrome  |            Fingerprint Scanner |
 | Android | Firefox |                     Screen PIN |
 
-The FIDO Alliance [maintains a list of what currently supports WebAuthn](https://fidoalliance.org/fido2/fido2-web-authentication-webauthn/). If "WebAuthn API" is green, that combination of browser and OS *should* work fine with WebAuthntine. That said, WebAuthntine isn't perfect, so pull requests are welcome!
+The FIDO Alliance [maintains a list of what currently supports WebAuthn](https://fidoalliance.org/fido2/fido2-web-authentication-webauthn/). If "WebAuthn API" is green, that combination of browser and OS *should* work fine with SimpleWebAuthn. That said, SimpleWebAuthn isn't perfect, so pull requests are welcome!
 
 ## Development
 
@@ -77,7 +77,7 @@ $> npx lerna run test
 Running Jest in watch mode for a specific project requires the use of `lerna exec`:
 
 ```sh
-$> npx lerna exec npm run test:watch --scope=@webauthntine/server
+$> npx lerna exec npm run test:watch --scope=@simplewebauthn/server
 ```
 
 ## Pronunciation Guide

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
-# WebAuthntine Example
+# SimpleWebAuthn Example
 
-A fully-functional reference implementation of [@webauthntine/server](../packages/server) and [@webauthntine/browser](../packages/browser).
+A fully-functional reference implementation of [@simplewebauthn/server](../packages/server) and [@simplewebauthn/browser](../packages/browser).
 
 ## Requirements
 

--- a/example/index.js
+++ b/example/index.js
@@ -192,6 +192,7 @@ app.get('/generate-assertion-options', (req, res) => {
   res.send(
     generateAssertionOptions(
       challenge,
+      60000,
       user.devices.map(data => data.base64CredentialID),
     ),
   );

--- a/example/index.js
+++ b/example/index.js
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /**
- * An example Express server showing off a simple integration of @webauthntine/server.
+ * An example Express server showing off a simple integration of @simplewebauthn/server.
  *
- * The webpages served from ./public use @webauthntine/browser.
+ * The webpages served from ./public use @simplewebauthn/browser.
  */
 const https = require('https');
 const fs = require('fs');
@@ -16,7 +16,7 @@ const {
   // Login ("Assertion")
   generateAssertionOptions,
   verifyAssertionResponse,
-} = require('@webauthntine/server');
+} = require('@simplewebauthn/server');
 
 const app = express();
 const host = '0.0.0.0';
@@ -39,7 +39,7 @@ const origin = `https://${rpID}`;
  *
  * Here, the example server assumes the following user has completed login:
  */
-const loggedInUserId = 'webauthntineInternalUserId';
+const loggedInUserId = 'internalUserId';
 
 /**
  * You'll need a database to store a few things:
@@ -117,7 +117,7 @@ app.get('/generate-attestation-options', (req, res) => {
 
   res.send(
     generateAttestationOptions(
-      'WebAuthntine Example',
+      'SimpleWebAuthn Example',
       rpID,
       challenge,
       loggedInUserId,

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -25,12 +25,12 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@webauthntine/server": {
+    "@simplewebauthn/server": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@webauthntine/server/-/server-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-0.2.3.tgz",
       "integrity": "sha512-/UJ1irJUsaH7dRccl7VtV0dclE359vBORUxMqyzO7WrcVOmi49ihbuCOzpjF4CPT+hIszFEzYqKPwrjFkkzIPg==",
       "requires": {
-        "@webauthntine/typescript-types": "^0.2.3",
+        "@simplewebauthn/typescript-types": "^0.2.3",
         "base64url": "^3.0.1",
         "cbor": "^5.0.2",
         "elliptic": "^6.5.2",
@@ -38,9 +38,9 @@
         "node-rsa": "^1.0.8"
       }
     },
-    "@webauthntine/typescript-types": {
+    "@simplewebauthn/typescript-types": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@webauthntine/typescript-types/-/typescript-types-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/typescript-types/-/typescript-types-0.2.3.tgz",
       "integrity": "sha512-GA7vTKY0sFaLE7dOKrtcs32EDM64exah+cMZO959gozZhRconH9s4qVccSqF+aInLkdh3tveqFTlWisKS95ymQ=="
     },
     "abbrev": {

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@webauthntine/server": "^0.2.3",
+    "@simplewebauthn/server": "^0.2.3",
     "express": "^4.17.1"
   },
   "devDependencies": {

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./styles.css" />
-    <title>WebAuthntine Example Site</title>
+    <title>SimpleWebAuthn Example Site</title>
   </head>
   <body>
     <div class="container">
-      <h1>WebAuthntine Example Site</h1>
+      <h1>SimpleWebAuthn Example Site</h1>
       <p>🚪&nbsp;<a href="/register">Register</a></p>
       <p>🔐&nbsp;<a href="/login">Login</a></p>
     </div>

--- a/example/public/login/index.html
+++ b/example/public/login/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="https://unpkg.com/@webauthntine/browser@0.2.3/dist/webauthntine-browser.min.js"></script>
+    <script src="https://unpkg.com/@simplewebauthn/browser@0.2.3/dist/simplewebauthn-browser.min.js"></script>
     <link rel="stylesheet" href="../styles.css" />
-    <title>WebAuthntine Example Site | Login</title>
+    <title>SimpleWebAuthn Example Site | Login</title>
   </head>
   <body>
     <div class="container">
@@ -23,7 +23,7 @@
       const elemSuccess = document.getElementById('success');
       const elemError = document.getElementById('error');
 
-      const { startAssertion } = WebAuthntineBrowser;
+      const { startAssertion } = SimpleWebAuthnBrowser;
 
       elemBegin.addEventListener('click', async () => {
         // Reset success/error messages

--- a/example/public/register/index.html
+++ b/example/public/register/index.html
@@ -3,9 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script src="https://unpkg.com/@webauthntine/browser@0.2.3/dist/webauthntine-browser.min.js"></script>
+    <script src="https://unpkg.com/@simplewebauthn/browser@0.2.3/dist/simplewebauthn-browser.min.js"></script>
     <link rel="stylesheet" href="../styles.css" />
-    <title>WebAuthntine Example Site | Register</title>
+    <title>SimpleWebAuthn Example Site | Register</title>
   </head>
   <body>
     <div class="container">
@@ -23,7 +23,7 @@
       const elemSuccess = document.getElementById('success');
       const elemError = document.getElementById('error');
 
-      const { startAttestation } = WebAuthntineBrowser;
+      const { startAttestation } = SimpleWebAuthnBrowser;
 
       elemBegin.addEventListener('click', async () => {
         // Reset success/error messages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "webauthntine-monorepo",
+  "name": "simplewebauthn-monorepo",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "webauthntine-monorepo",
+  "name": "simplewebauthn-monorepo",
   "private": true,
   "scripts": {
-    "bootstrap": "lerna bootstrap --scope=@webauthntine/typescript-types && lerna bootstrap --scope=@webauthntine/browser --scope=@webauthntine/server",
+    "bootstrap": "lerna bootstrap --scope=@simplewebauthn/typescript-types && lerna bootstrap --scope=@simplewebauthn/browser --scope=@simplewebauthn/server",
     "lint": "prettier --write packages/ example/ && eslint --fix packages/ example/"
   },
   "devDependencies": {

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,9 +1,9 @@
 <!-- omit in toc -->
 
-# @webauthntine/browser
+# @simplewebauthn/browser
 
 ![WebAuthn](https://img.shields.io/badge/WebAuthn-Simplified-blueviolet?style=for-the-badge&logo=WebAuthn)
-[![npm (scoped)](https://img.shields.io/npm/v/@webauthntine/browser?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@webauthntine/browser)
+[![npm (scoped)](https://img.shields.io/npm/v/@simplewebauthn/browser?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@simplewebauthn/browser)
 ![Browser Support](https://img.shields.io/badge/Browser-ES2018+-brightgreen?style=for-the-badge&logo=Mozilla+Firefox)
 
 - [Installation](#installation)
@@ -15,13 +15,13 @@
 This package is available on **npm**:
 
 ```sh
-npm install @webauthntine/browser
+npm install @simplewebauthn/browser
 ```
 
 It can then be imported into a project as usual:
 
 ```js
-import WebAuthntineBrowser from '@webauthntine/browser';
+import SimpleWebAuthnBrowser from '@simplewebauthn/browser';
 ```
 
 ### UMD
@@ -29,10 +29,10 @@ import WebAuthntineBrowser from '@webauthntine/browser';
 This package can also be installed via **unpkg** by including the following script in your page's `<head>` element:
 
 ```html
-<script src="https://unpkg.com/@webauthntine/browser/dist/webauthntine-browser.min.js"></script>
+<script src="https://unpkg.com/@simplewebauthn/browser/dist/simplewebauthn-browser.min.js"></script>
 ```
 
-The library's methods will be available on the global `WebAuthntineBrowser` object.
+The library's methods will be available on the global `SimpleWebAuthnBrowser` object.
 
 ## Usage - Coming Soon
 

--- a/packages/browser/package-lock.json
+++ b/packages/browser/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@webauthntine/browser",
+  "name": "@simplewebauthn/browser",
   "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
@@ -185,7 +185,7 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@webauthntine/typescript-types": {
+    "@simplewebauthn/typescript-types": {
       "version": "file:../typescript-types",
       "dev": true
     },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@webauthntine/browser",
+  "name": "@simplewebauthn/browser",
   "version": "0.2.3",
-  "description": "WebAuthntine for Browsers",
-  "main": "dist/webauthntine-browser.min.js",
+  "description": "SimpleWebAuthn for Browsers",
+  "main": "dist/simplewebauthn-browser.min.js",
   "types": "dist/index.d.ts",
   "author": "Matthew Miller <matthew@millerti.me>",
   "license": "MIT",
-  "homepage": "https://github.com/MasterKale/WebAuthntine/packages/browser#readme",
+  "homepage": "https://github.com/MasterKale/SimpleWebAuthn/packages/browser#readme",
   "publishConfig": {
     "access": "public"
   },
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/base64-js": "^1.2.5",
-    "@webauthntine/typescript-types": "file:../typescript-types",
+    "@simplewebauthn/typescript-types": "file:../typescript-types",
     "ts-loader": "^7.0.4",
     "webpack": "^4.43.0",
     "webpack-auto-inject-version": "^1.2.2",

--- a/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
+++ b/packages/browser/src/helpers/toPublicKeyCredentialDescriptor.ts
@@ -1,5 +1,5 @@
 import base64js from 'base64-js';
-import type { PublicKeyCredentialDescriptorJSON } from '@webauthntine/typescript-types';
+import type { PublicKeyCredentialDescriptorJSON } from '@simplewebauthn/typescript-types';
 
 export default function toPublicKeyCredentialDescriptor(
   descriptor: PublicKeyCredentialDescriptorJSON,

--- a/packages/browser/src/methods/startAssertion.test.ts
+++ b/packages/browser/src/methods/startAssertion.test.ts
@@ -3,7 +3,7 @@ import base64js from 'base64-js';
 import {
   AssertionCredential,
   PublicKeyCredentialRequestOptionsJSON,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 import toUint8Array from '../helpers/toUint8Array';
 import supportsWebauthn from '../helpers/supportsWebauthn';

--- a/packages/browser/src/methods/startAssertion.ts
+++ b/packages/browser/src/methods/startAssertion.ts
@@ -2,7 +2,7 @@ import {
   PublicKeyCredentialRequestOptionsJSON,
   AuthenticatorAssertionResponseJSON,
   AssertionCredential,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 import toUint8Array from '../helpers/toUint8Array';
 import toBase64String from '../helpers/toBase64String';
@@ -12,7 +12,7 @@ import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDes
 /**
  * Begin authenticator "login" via WebAuthn assertion
  *
- * @param requestOptionsJSON Output from @webauthntine/server's generateAssertionOptions(...)
+ * @param requestOptionsJSON Output from @simplewebauthn/server's generateAssertionOptions(...)
  */
 export default async function startAssertion(
   requestOptionsJSON: PublicKeyCredentialRequestOptionsJSON,

--- a/packages/browser/src/methods/startAttestation.test.ts
+++ b/packages/browser/src/methods/startAttestation.test.ts
@@ -3,7 +3,7 @@ import base64js from 'base64-js';
 import {
   AttestationCredential,
   PublicKeyCredentialCreationOptionsJSON,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 import toUint8Array from '../helpers/toUint8Array';
 import supportsWebauthn from '../helpers/supportsWebauthn';
@@ -30,7 +30,7 @@ const goodOpts1: PublicKeyCredentialCreationOptionsJSON = {
     ],
     rp: {
       id: '1234',
-      name: 'webauthntine',
+      name: 'simplewebauthn',
     },
     user: {
       id: '5678',

--- a/packages/browser/src/methods/startAttestation.ts
+++ b/packages/browser/src/methods/startAttestation.ts
@@ -2,7 +2,7 @@ import {
   PublicKeyCredentialCreationOptionsJSON,
   AuthenticatorAttestationResponseJSON,
   AttestationCredential,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 import toUint8Array from '../helpers/toUint8Array';
 import toBase64String from '../helpers/toBase64String';
@@ -12,7 +12,7 @@ import toPublicKeyCredentialDescriptor from '../helpers/toPublicKeyCredentialDes
 /**
  * Begin authenticator "registration" via WebAuthn attestation
  *
- * @param creationOptionsJSON Output from @webauthntine/server's generateAttestationOptions(...)
+ * @param creationOptionsJSON Output from @simplewebauthn/server's generateAttestationOptions(...)
  */
 export default async function startAttestation(
   creationOptionsJSON: PublicKeyCredentialCreationOptionsJSON,

--- a/packages/browser/webpack.config.js
+++ b/packages/browser/webpack.config.js
@@ -21,8 +21,8 @@ module.exports = {
   },
   output: {
     path: outputPath,
-    filename: 'webauthntine-browser.min.js',
-    library: 'WebAuthntineBrowser',
+    filename: 'simplewebauthn-browser.min.js',
+    library: 'SimpleWebAuthnBrowser',
     libraryTarget: 'umd',
     globalObject: 'this',
   },

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,10 +1,10 @@
 <!-- omit in toc -->
 
-# @webauthntine/server
+# @simplewebauthn/server
 
 ![WebAuthn](https://img.shields.io/badge/WebAuthn-Simplified-blueviolet?style=for-the-badge&logo=WebAuthn)
-[![npm (scoped)](https://img.shields.io/npm/v/@webauthntine/server?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@webauthntine/server)
-![node-lts (scoped)](https://img.shields.io/node/v/@webauthntine/server?style=for-the-badge&logo=Node.js)
+[![npm (scoped)](https://img.shields.io/npm/v/@simplewebauthn/server?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@simplewebauthn/server)
+![node-lts (scoped)](https://img.shields.io/node/v/@simplewebauthn/server?style=for-the-badge&logo=Node.js)
 
 - [Installation](#installation)
 - [Usage - Coming Soon](#usage---coming-soon)
@@ -15,16 +15,16 @@
 This package is available on **npm**:
 
 ```sh
-npm install @webauthntine/server
+npm install @simplewebauthn/server
 ```
 
 It can then be imported into a Node project as usual:
 
 ```js
 // ESModule
-import WebAuthntineServer from '@webauthntine/server';
+import SimpleWebAuthnServer from '@simplewebauthn/server';
 // CommonJS
-const WebAuthntineServer = require('@webauthntine/server');
+const SimpleWebAuthnServer = require('@simplewebauthn/server');
 ```
 
 ## Usage - Coming Soon
@@ -33,7 +33,7 @@ Check out [the example](../../example/index.js) for now until this section gets 
 
 ## Supported Attestation Formats
 
-WebAuthntine can verify the following attestation formats:
+SimpleWebAuthn can verify the following attestation formats:
 
 - `fido-u2f`
 - `packed`

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@webauthntine/server",
+  "name": "@simplewebauthn/server",
   "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@webauthntine/typescript-types": {
+    "@simplewebauthn/typescript-types": {
       "version": "file:../typescript-types"
     },
     "asn1": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@webauthntine/server",
+  "name": "@simplewebauthn/server",
   "version": "0.2.3",
-  "description": "WebAuthntine for Servers",
+  "description": "SimpleWebAuthn for Servers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Matthew Miller <matthew@millerti.me>",
   "license": "MIT",
-  "homepage": "https://github.com/MasterKale/WebAuthntine/packages/server#readme",
+  "homepage": "https://github.com/MasterKale/SimpleWebAuthn/packages/server#readme",
   "publishConfig": {
     "access": "public"
   },
@@ -26,7 +26,7 @@
     "node"
   ],
   "dependencies": {
-    "@webauthntine/typescript-types": "file:../typescript-types",
+    "@simplewebauthn/typescript-types": "file:../typescript-types",
     "base64url": "^3.0.1",
     "cbor": "^5.0.2",
     "elliptic": "^6.5.2",

--- a/packages/server/src/assertion/generateAssertionOptions.test.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.test.ts
@@ -5,11 +5,11 @@ test('should generate credential request options suitable for sending via JSON',
 
   const options = generateAssertionOptions(
     challenge,
+    1,
     [
       Buffer.from('1234', 'ascii').toString('base64'),
       Buffer.from('5678', 'ascii').toString('base64'),
     ],
-    1,
   );
 
   expect(options).toEqual({
@@ -33,7 +33,7 @@ test('should generate credential request options suitable for sending via JSON',
 });
 
 test('defaults to 60 seconds if no timeout is specified', () => {
-  const options = generateAssertionOptions('totallyrandomvalue', [
+  const options = generateAssertionOptions('totallyrandomvalue', undefined, [
     Buffer.from('1234', 'ascii').toString('base64'),
     Buffer.from('5678', 'ascii').toString('base64'),
   ]);

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -13,8 +13,8 @@ import type {
  */
 export default function generateAssertionOptions(
   challenge: string,
-  allowedBase64CredentialIDs: string[],
   timeout = 60000,
+  allowedBase64CredentialIDs: string[],
   suggestedTransports: AuthenticatorTransport[] = ['usb', 'ble', 'nfc', 'internal'],
 ): PublicKeyCredentialRequestOptionsJSON {
   return {

--- a/packages/server/src/assertion/generateAssertionOptions.ts
+++ b/packages/server/src/assertion/generateAssertionOptions.ts
@@ -1,6 +1,6 @@
 import type {
   PublicKeyCredentialRequestOptionsJSON,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 /**
  * Prepare a value to pass into navigator.credentials.get(...) for authenticator "login"

--- a/packages/server/src/assertion/verifyAssertionResponse.ts
+++ b/packages/server/src/assertion/verifyAssertionResponse.ts
@@ -3,7 +3,7 @@ import {
   AuthenticatorAssertionResponseJSON,
   AuthenticatorDevice,
   VerifiedAssertion,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 import decodeClientDataJSON from '@helpers/decodeClientDataJSON';
 

--- a/packages/server/src/attestation/generateAttestationOptions.test.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.test.ts
@@ -1,7 +1,7 @@
 import generateAttestationOptions from './generateAttestationOptions';
 
 test('should generate credential request options suitable for sending via JSON', () => {
-  const serviceName = 'WebAuthntine';
+  const serviceName = 'SimpleWebAuthn';
   const rpID = 'not.real';
   const challenge = 'totallyrandomvalue';
   const userID = '1234';
@@ -46,7 +46,7 @@ test('should generate credential request options suitable for sending via JSON',
 
 test('should map excluded credential IDs if specified', () => {
   const options = generateAttestationOptions(
-    'WebAuthntine',
+    'SimpleWebAuthn',
     'not.real',
     'totallyrandomvalue',
     '1234',
@@ -65,7 +65,7 @@ test('should map excluded credential IDs if specified', () => {
 
 test('defaults to 60 seconds if no timeout is specified', () => {
   const options = generateAttestationOptions(
-    'WebAuthntine',
+    'SimpleWebAuthn',
     'not.real',
     'totallyrandomvalue',
     '1234',
@@ -77,7 +77,7 @@ test('defaults to 60 seconds if no timeout is specified', () => {
 
 test('defaults to direct attestation if no attestation type is specified', () => {
   const options = generateAttestationOptions(
-    'WebAuthntine',
+    'SimpleWebAuthn',
     'not.real',
     'totallyrandomvalue',
     '1234',

--- a/packages/server/src/attestation/generateAttestationOptions.ts
+++ b/packages/server/src/attestation/generateAttestationOptions.ts
@@ -1,4 +1,4 @@
-import { PublicKeyCredentialCreationOptionsJSON } from '@webauthntine/typescript-types';
+import { PublicKeyCredentialCreationOptionsJSON } from '@simplewebauthn/typescript-types';
 
 /**
  * Prepare a value to pass into navigator.credentials.create(...) for authenticator "registration"

--- a/packages/server/src/attestation/verifications/verifyAndroidSafetyNet.ts
+++ b/packages/server/src/attestation/verifications/verifyAndroidSafetyNet.ts
@@ -5,7 +5,7 @@ import {
   SafetyNetJWTHeader,
   SafetyNetJWTPayload,
   SafetyNetJWTSignature,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 import toHash from '@helpers/toHash';
 import verifySignature from '@helpers/verifySignature';

--- a/packages/server/src/attestation/verifications/verifyFIDOU2F.ts
+++ b/packages/server/src/attestation/verifications/verifyFIDOU2F.ts
@@ -1,5 +1,5 @@
 import base64url from 'base64url';
-import { AttestationObject, VerifiedAttestation } from '@webauthntine/typescript-types';
+import { AttestationObject, VerifiedAttestation } from '@simplewebauthn/typescript-types';
 
 import toHash from '@helpers/toHash';
 import convertCOSEtoPKCS from '@helpers/convertCOSEtoPKCS';

--- a/packages/server/src/attestation/verifications/verifyNone.ts
+++ b/packages/server/src/attestation/verifications/verifyNone.ts
@@ -1,5 +1,5 @@
 import base64url from 'base64url';
-import { AttestationObject, VerifiedAttestation } from '@webauthntine/typescript-types';
+import { AttestationObject, VerifiedAttestation } from '@simplewebauthn/typescript-types';
 
 import convertCOSEtoPKCS from '@helpers/convertCOSEtoPKCS';
 import parseAuthenticatorData from '@helpers/parseAuthenticatorData';

--- a/packages/server/src/attestation/verifications/verifyPacked.ts
+++ b/packages/server/src/attestation/verifications/verifyPacked.ts
@@ -7,7 +7,7 @@ import {
   VerifiedAttestation,
   COSEKEYS,
   COSEPublicKey as COSEPublicKeyType,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 import convertCOSEtoPKCS from '@helpers/convertCOSEtoPKCS';
 import toHash from '@helpers/toHash';

--- a/packages/server/src/attestation/verifyAttestationResponse.ts
+++ b/packages/server/src/attestation/verifyAttestationResponse.ts
@@ -4,7 +4,7 @@ import {
   ATTESTATION_FORMATS,
   AuthenticatorAttestationResponseJSON,
   VerifiedAttestation,
-} from '@webauthntine/typescript-types';
+} from '@simplewebauthn/typescript-types';
 
 import verifyFIDOU2F from './verifications/verifyFIDOU2F';
 import verifyPacked from './verifications/verifyPacked';

--- a/packages/server/src/helpers/convertCOSEtoPKCS.test.ts
+++ b/packages/server/src/helpers/convertCOSEtoPKCS.test.ts
@@ -1,5 +1,5 @@
 import cbor from 'cbor';
-import { COSEKEYS } from '@webauthntine/typescript-types';
+import { COSEKEYS } from '@simplewebauthn/typescript-types';
 
 import convertCOSEtoPKCS from './convertCOSEtoPKCS';
 

--- a/packages/server/src/helpers/convertCOSEtoPKCS.ts
+++ b/packages/server/src/helpers/convertCOSEtoPKCS.ts
@@ -1,5 +1,5 @@
 import cbor from 'cbor';
-import { COSEKEYS, COSEPublicKey } from '@webauthntine/typescript-types';
+import { COSEKEYS, COSEPublicKey } from '@simplewebauthn/typescript-types';
 
 /**
  * Takes COSE-encoded public key and converts it to PKCS key

--- a/packages/server/src/helpers/decodeAttestationObject.ts
+++ b/packages/server/src/helpers/decodeAttestationObject.ts
@@ -1,6 +1,6 @@
 import base64url from 'base64url';
 import cbor from 'cbor';
-import { AttestationObject } from '@webauthntine/typescript-types';
+import { AttestationObject } from '@simplewebauthn/typescript-types';
 
 /**
  * Convert an AttestationObject from base64 string to a proper object

--- a/packages/server/src/helpers/decodeClientDataJSON.ts
+++ b/packages/server/src/helpers/decodeClientDataJSON.ts
@@ -1,4 +1,4 @@
-import { ClientDataJSON } from '@webauthntine/typescript-types';
+import { ClientDataJSON } from '@simplewebauthn/typescript-types';
 
 import asciiToBinary from './asciiToBinary';
 

--- a/packages/server/src/helpers/getCertificateInfo.ts
+++ b/packages/server/src/helpers/getCertificateInfo.ts
@@ -1,5 +1,5 @@
 import jsrsasign from 'jsrsasign';
-import { CertificateInfo } from '@webauthntine/typescript-types';
+import { CertificateInfo } from '@simplewebauthn/typescript-types';
 
 type ExtInfo = {
   critical: boolean;

--- a/packages/server/src/helpers/parseAuthenticatorData.ts
+++ b/packages/server/src/helpers/parseAuthenticatorData.ts
@@ -1,4 +1,4 @@
-import { ParsedAuthenticatorData } from '@webauthntine/typescript-types';
+import { ParsedAuthenticatorData } from '@simplewebauthn/typescript-types';
 
 /**
  * Make sense of the authData buffer contained in an Attestation

--- a/packages/typescript-types/README.md
+++ b/packages/typescript-types/README.md
@@ -1,6 +1,6 @@
-# @webauthntine/typescript-types
+# @simplewebauthn/typescript-types
 
 ![WebAuthn](https://img.shields.io/badge/WebAuthn-Simplified-blueviolet?style=for-the-badge&logo=WebAuthn)
-[![npm (scoped)](https://img.shields.io/npm/v/@webauthntine/typescript-types?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@webauthntine/typescript-types)
+[![npm (scoped)](https://img.shields.io/npm/v/@simplewebauthn/typescript-types?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@simplewebauthn/typescript-types)
 
-TypeScript typings for [@webauthntine/server](../server/) and [@webauthntine/browser](../browser/)
+TypeScript typings for [@simplewebauthn/server](../server/) and [@simplewebauthn/browser](../browser/)

--- a/packages/typescript-types/package-lock.json
+++ b/packages/typescript-types/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@webauthntine/typescript-types",
+  "name": "@simplewebauthn/typescript-types",
   "version": "0.2.3",
   "lockfileVersion": 1
 }

--- a/packages/typescript-types/package.json
+++ b/packages/typescript-types/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@webauthntine/typescript-types",
+  "name": "@simplewebauthn/typescript-types",
   "version": "0.2.3",
-  "description": "TypeScript types used by the @webauthntine series of libraries",
+  "description": "TypeScript types used by the @simplewebauthn series of libraries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Matthew Miller <matthew@millerti.me>",
   "license": "MIT",
-  "homepage": "https://github.com/MasterKale/WebAuthntine/packages/typescript-types#readme",
+  "homepage": "https://github.com/MasterKale/SimpleWebAuthn/packages/typescript-types#readme",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
After some consideration I've decided to rename the project to **"SimpleWebAuthn"**. It's hopefully catchier/easier to remember, and removes most of the pronunciation ambiguity.

The project will now be published under the **@simplewebauthn** scope on npm.